### PR TITLE
Add P5R savefile and Metaphor events

### DIFF
--- a/metaphor/common/colors.hexpat
+++ b/metaphor/common/colors.hexpat
@@ -1,0 +1,19 @@
+struct f32RGBA {
+    float r;
+    float g;
+    float b;
+    float a;
+}[[hex::inline_visualize("color", r * 255, g * 255, b * 255, a * 255)]];
+
+struct f32RGB {
+    float r;
+    float g;
+    float b;
+}[[hex::inline_visualize("color", r * 255, g * 255, b * 255, 255)]];
+
+struct u8RGBA {
+    u8 r;
+    u8 g;
+    u8 b;
+    u8 a;
+}[[hex::inline_visualize("color", r, g, b, a)]];

--- a/metaphor/evt.hexpat
+++ b/metaphor/evt.hexpat
@@ -1,0 +1,1209 @@
+#pragma author Rirurin
+#pragma description Template for reading event files from Metaphor: Refantazio (EVT and ECS)
+
+#include <hex/provider.pat>
+#include <std/io.pat>
+#include <std/string.pat>
+#include <std/sys.pat>
+#include <atlus/metaphor/common/colors.hexpat>
+#include <atlus/p5r/common/numerics.expat>
+
+using f32 = float;
+
+fn fmt_fixed_length_string(ref str data) {
+    return std::format("{}", data);
+};
+
+struct EvtHeader {
+    char Magic[3];
+    u8 Endian;
+    u32 Version;
+    u16 MajorID;
+    u16 MinorID;
+    u8 Rank;
+    u8 Level;
+    u8 Chapter;
+    u8 Field0F[[hidden]];
+    u32 FileSize;
+    u32 FileHeaderSize;
+    u32 Flags;
+    s32 TotalFrame;
+    u8 FrameRate;
+    u8 InitScriptIndex;
+    u16 StartFrame;
+    u16 LetterBoxInFrame;
+    u16 Field26[[hidden]];
+    u32 InitEnvAssetID;
+    u32 InitEnvAssetIDDbg;
+    u32 AssetNums;
+    u32 AssetDataOfs;
+    u32 AssetDataSize;
+    u32 AssetReserve;
+    u32 CommandNums;
+    u32 CommandHeaderOfs;
+    u32 CommandHeaderSize;
+    u32 CommandReserve;
+    u32 MessagePathOfs;
+    u32 MessagePathSize;
+    u32 MessageFileOfs;
+    u32 MessageFileSize;
+    u32 ScriptPathOfs;
+    u32 ScriptPathSize;
+    u32 ScriptFileOfs;
+    u32 ScriptFileSize;
+    u32 MarkerFrame[8];
+    char InitScriptFilename[0x40][[format("fmt_fixed_length_string")]];
+    s32 TimeIndex;
+    s32 WeatherIndex;
+    s32 IgniterBGIndex;
+    s32 WipeIndex;
+    s32 IgniterPathIndex;
+    u8 Padding[FileHeaderSize - 0xe4][[hidden]];
+}[[format("fmt_evt_header")]];
+
+fn fmt_evt_header(ref EvtHeader self) {
+    return std::format("VER: 0x{:x}, ID: e{:02}_{:03}_{:03}, RANK: {}, LEVEL: {}", self.Version, self.Chapter, self.MajorID, self.MinorID, self.Rank, self.Level);
+};
+
+struct EcsHeader {
+    u32 CommandNums;
+    u32 CommandHeaderOfs;
+    u32 CommandHeaderSize;
+    u32 CommandReserve;
+}[[static]];
+
+struct Animation {
+    s32 Type;
+    s32 Category;
+    s32 Chapter;
+    s32 Major;
+    s32 Minor;
+    s32 Sub;
+    char FilePath[256][[format("fmt_fixed_length_string")]];
+}[[static]];
+
+struct Object {
+    s32 AssetID;
+    s32 ResrcTypeID;
+    s32 ResrcCategory;
+    s32 ResrcUniqueID;
+    s32 ResrcMajorID;
+    s16 ResrcSubID;
+    s16 ResrcMinorID;
+    u32 Flags;
+    u32 BaseMotNo;
+    u32 ExtBaseMotNo;
+    Animation baseAnimData;
+    Animation baseAnimExtData;
+    Animation additiveAnimData;
+    Animation facialAnimData;
+    u32 Field464;
+    u32 Field468;
+    u32 TexIndex;
+    char OverwriteLabel[64][[format("fmt_fixed_length_string")]];
+    char CaptureLabel[64][[format("fmt_fixed_length_string")]];
+}[[name(std::format("ID: {}", AssetID))]];
+
+// Command types (mostly) automatically generated from script in xrd759-inspector/detail_panel/event.rs (Metaphor Multiplayer)
+
+struct CAMERA_MOVE_DIRECT {
+    u32 Flags; // 0x0
+    vector3 Pos; // 0x4
+    euler AngleDeg; // 0x10
+    f32 FovY; // 0x1c
+    padding[8];
+    u32 InterpParam; // 0x28
+    f32 FocalPlane; // 0x2c
+    f32 NearPlaneOffset; // 0x30
+    f32 FarPlaneOffset; // 0x34
+    f32 FarBlurLimit; // 0x38
+    f32 BlurSize; // 0x3c
+    f32 BlurAngle; // 0x40
+    padding[4];
+    f32 BokehDistance; // 0x48
+};
+
+struct CAMERA_SET_ASSET {
+    u32 Flags; // 0x0
+    u32 AssetID; // 0x4
+    s32 AnimNo; // 0x8
+    f32 AnimSpeed; // 0xc
+    s32 AnimStartFrame; // 0x10
+    vector3 Pos; // 0x14
+    euler AngleDeg; // 0x20
+    padding[4];
+    f32 FocalPlane; // 0x30
+    f32 NearPlaneOffset; // 0x34
+    f32 FarPlaneOffset; // 0x38
+    f32 FarBlurLimit; // 0x3c
+    f32 BlurSize; // 0x40
+    f32 BlurAngle; // 0x44
+    padding[4];
+    f32 BokehDistance; // 0x4c
+    padding[0x14];
+    f32 NearClipPlane; // 0x60
+    f32 FarClipPlane; // 0x64
+};
+
+struct CAMERA_SET_DIRECT {
+    u32 Flags; // 0x0
+    vector3 Pos; // 0x4
+    euler AngleDeg; // 0x10
+    f32 FovY; // 0x1c
+    padding[8];
+    f32 FocalPlane; // 0x28
+    f32 NearPlaneOffset; // 0x2c
+    f32 FarPlaneOffset; // 0x30
+    f32 FarBlurLimit; // 0x34
+    f32 BlurSize; // 0x38
+    f32 BlurAngle; // 0x3c
+    padding[4];
+    f32 BokehDistance; // 0x44
+    padding[4];
+    f32 NearClipPlane; // 0x4c
+    f32 FarClipPlane; // 0x50
+};
+
+struct CAMERA_SET_FIELD {
+    u32 Flags; // 0x0
+    s32 AssetID; // 0x4
+    s32 CameraUID; // 0x8
+    f32 FocalPlane; // 0xc
+    f32 NearPlaneOffset; // 0x10
+    f32 FarPlaneOffset; // 0x14
+    f32 FarBlurLimit; // 0x18
+    f32 BlurSize; // 0x1c
+    f32 BlurAngle; // 0x20
+    f32 BokehDistance; // 0x24
+};
+
+struct CAMERA_SHAKE {
+    u32 Flags; // 0x0
+    s32 Mode; // 0x4
+    s32 Type; // 0x8
+    f32 Scale; // 0xc
+    f32 Speed; // 0x10
+};
+
+struct EFFECT_ALPHA {
+    u32 Flags; // 0x0
+    padding[3];
+    u8 AlphaValue; // 0x7
+    u32 InterpParam; // 0x8
+};
+
+struct EFFECT_REGISTER {
+    u32 Flags; // 0x0
+    u32 RegisterType; // 0x4
+    u32 SceneType; // 0x8
+};
+
+struct EFFECT_SCALE {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 Scale; // 0x8
+};
+
+struct EFFECT_SET_DIRECT {
+    u32 Flags; // 0x0
+    vector3 Pos; // 0x4
+    euler AngleDeg; // 0x10
+};
+
+struct EFFECT_SET_HELPER {
+    u32 Flags; // 0x0
+    u16 FrameLengthIn; // 0x4
+    u16 FrameLengthOut; // 0x6
+    u32 InterpParamIn; // 0x8
+    u32 InterpParamOut; // 0xc
+    u32 TargetAssetID; // 0x10
+    u32 HelperID; // 0x14
+};
+
+struct ENV_CLOUD {
+    u32 Flags; // 0x0
+    f32 GlobalDensity; // 0x4
+    f32 Phase; // 0x8
+    f32 Coverage; // 0xc
+    f32 Type; // 0x10
+    f32 Wetness; // 0x14
+    f32 WindSpeed; // 0x18
+    f32 WindAngle; // 0x1c
+    s32 StepMaxNum; // 0x20
+    padding[4];
+    f32RGBA Color; // 0x28
+};
+
+struct ENV_DIFFUSION {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 Scale; // 0x8
+    f32 Bias; // 0xc
+};
+
+struct ENV_PLANE_GRADATION {
+    u32 Flags; // 0x0
+    vector3 PlanePos; // 0x4
+    f32 PlaneDistance; // 0x10
+    euler PlaneRot; // 0x14
+    f32RGB LightColor; // 0x20
+    f32RGB ShadowColor; // 0x2c
+    f32 Attenuation; // 0x38
+    f32 Factor; // 0x3c
+};
+
+struct ENV_SET {
+    u32 Flags; // 0x0
+    u32 AssetID; // 0x4
+};
+
+struct ENV_BGCOLOR {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    padding[4];
+    u8RGBA ColorRGBA; // 0xc
+};
+
+struct ENV_CORRECT {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 Cyan; // 0x8
+    f32 Magenta; // 0xc
+    f32 Yellow; // 0x10
+    f32 Dodge; // 0x14
+    f32 Burn; // 0x18
+};
+
+struct ENV_DOF {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 FocalPlane; // 0x8
+    f32 NearPlaneOffset; // 0xc
+    f32 FarPlaneOffset; // 0x10
+    f32 FarBlurLimit; // 0x14
+    f32 BlurSize; // 0x18
+    f32 BlurAngle; // 0x1c
+    padding[8];
+    f32 BokehDistance; // 0x24
+};
+
+struct ENV_EXPONENTIAL_FOG {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 FogHeight; // 0x8
+    f32 FogDensity; // 0xc
+    f32 FogHeightFalloff; // 0x10
+    f32 FogMaxOpacity; // 0x14
+    f32 StartDistance; // 0x18
+    f32 LightTerminatorAngle; // 0x1c
+    f32RGB FogColor; // 0x20
+    f32 FogColorIntensity; // 0x2c
+    f32 DirInscatExponent; // 0x30
+    padding[4];
+    f32RGB DirInscatColor; // 0x38
+    f32 DirInscatStartDistance; // 0x34
+    padding[12];
+    f32 DirInscatColorIntensity; // 0x44
+};
+
+struct ENV_HDR {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    padding[8];
+    f32 ToonIntensity; // 0x10
+    f32 BloomScale; // 0x14
+    f32 AdaptedLum; // 0x18
+    f32 ElapsedTime; // 0x1c
+    s32 StarNumLines; // 0x20
+    f32 StarLength; // 0x24
+    f32 StarScale; // 0x28
+    f32 StarGlareCA; // 0x2c
+    f32 StarGlareSI; // 0x30
+    f32 DiffusionMiddleGray; // 0x34
+    f32 DiffusionScale; // 0x38
+    f32 DiffusionAdaptedLum; // 0x3c
+};
+
+struct ENV_LIGHT_0 {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 Intensity; // 0x8
+    u8RGBA AmbientColorRGBA; // 0x10
+    u8RGBA DiffuseColorRGBA; // 0x14
+    u8RGBA SpecularColorRGBA; // 0x18
+    vector3 DirVec; // 0x1c
+};
+
+struct ENV_LIGHT_1 {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 ColorIntensity; // 0x8
+    f32 SpecularIntensity; // 0xc
+    u8RGBA AmbientColorRGBA; // 0x10
+    u8RGBA DiffuseColorRGBA; // 0x14
+    padding[4];
+    vector3 DirVec; // 0x1c
+};
+
+struct ENV_OUTLINE {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 Range; // 0x8
+    f32 Width; // 0xc
+    f32 Brightness; // 0x10
+    f32 GeometryRangeStart; // 0x14
+    f32 GeometryRangeEnd; // 0x18
+    f32 ThinMax; // 0x1c
+    f32 ThinFadeStart; // 0x20
+    f32 ThinFadeEnd; // 0x24
+};
+
+struct ENV_PHYSICS {
+    u32 Flags; // 0x0
+};
+
+struct ENV_SHADOW {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    padding[8];
+    u32 ShadowFlags; // 0x10
+    f32 DepthRange; // 0x14
+    f32 BiasPBR; // 0x18
+    f32 BiasOther; // 0x1c
+    f32 Split; // 0x20
+    f32 BorderTile; // 0x24
+    f32 BorderScale; // 0x28
+    f32 PatternTile; // 0x2c
+    f32 PatternAlpha; // 0x30
+    f32 Alpha; // 0x34
+};
+
+struct ENV_SKYDOME {
+    u32 Flags; // 0x0
+};
+
+struct ENV_SSAO {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    padding[8];
+    f32 DepthRange; // 0x10
+    f32 OccluderRadius; // 0x14
+    f32 FalloffRadius; // 0x18
+    f32 Brightness; // 0x1c
+    f32 BlurScale; // 0x20
+};
+
+struct FADE {
+    u32 Flags; // 0x0
+    u8 ActionIndex; // 0x4
+    u8 ColorIndex; // 0x5
+    padding[2];
+    s32 FadeOutOpIndices[10];
+    s32 FadeRate; // 0x30
+    s32 AnimTypeIndex; // 0x34
+    s32 BlendTypeIndex; // 0x38
+    u32 CustomColor; // 0x3c
+};
+
+struct FIELD_FEATURE_DISP {
+    u32 Flags; // 0x0
+};
+
+struct FIELD_LIGHTS {
+    u32 Flags; // 0x0
+    f32 IntensityScale; // 0x4
+};
+
+struct FIELD_MOB_DISP {
+    u32 Flags; // 0x0
+};
+
+struct FIELD_MOB_DISP_BOX {
+    u32 Flags; // 0x0
+    vector3 Pos; // 0x4
+    euler AngleDeg; // 0x10
+    vector3 Scale; // 0x1c
+};
+
+struct FIELD_OBJ_ANIM_BASE {
+    u32 Flags; // 0x0
+    s32 ObjectIDTypeIndex; // 0x4
+    s32 ObjectID; // 0x8
+    s32 AnimNo; // 0xc
+    s32 AnimStartFrame; // 0x10
+    s32 AnimEndFrame; // 0x14
+    s32 AnimBlendFrame; // 0x18
+    s32 AnimFlags; // 0x1c
+    f32 AnimSpeed; // 0x20
+};
+
+struct FIELD_OBJ_DISP {
+    u32 Flags; // 0x0
+    s32 ObjectID; // 0x4
+    s32 ObjectIDTypeIndex; // 0x8
+};
+
+struct FIELD_SET {
+    u32 Flags; // 0x0
+    s32 DivNo; // 0x4
+    padding[8];
+    vector3 Pos; // 0x10
+    euler RotDeg; // 0x1c
+    vector3 RotBasePos; // 0x28
+};
+
+struct FRAME_JUMP {
+    s32 Frame; // 0x0
+};
+
+struct FRAME_UNSKIPPABLE {
+    u32 Flags; // 0x0
+};
+
+struct GAME_BASE_PARAM_UP {
+    u32 Flags; // 0x0
+    s32 CharaIDIndex; // 0x4
+    s32 ParamIndex; // 0x8
+    s32 Value; // 0xc
+    s32 ReferredEnumLength; // 0x10
+    char ReferredEnumName[0x40][[format("fmt_fixed_length_string")]]; // 0x14
+};
+
+struct GAME_DATE {
+    u32 Flags; // 0x0
+    s32 MonthIndex; // 0x4
+    s32 Day; // 0x8
+    s32 TimeIndex; // 0xc
+    s32 WeatherIndex; // 0x10
+    s32 Temperature; // 0x18
+};
+
+struct GAME_FOLLOWER_RANK_UP {
+    u32 FollowerIndex; // 0x0
+    u32 FollowerRank; // 0x4
+};
+
+struct GAME_HUMAN_PARAM_UP {
+    u32 Flags; // 0x0
+    s32 HeroAssetId; // 0x4
+    s32 ParamIndex; // 0x8
+    s32 ParamValue; // 0xc
+    s32 IconSizeIndex; // 0x10
+    padding[4];
+    f32 IconScale; // 0x18
+    vector3 IconPosOffset; // 0x1c
+    s32 ReferredEnumLength; // 0x28
+    char ReferredEnumName[0x40][[format("fmt_fixed_length_string")]]; // 0x2c
+};
+
+struct ItemLabelName {
+    char Name[0x40][[format("fmt_fixed_length_string")]];
+}[[format("fmt_item_label_name")]];
+
+fn fmt_item_label_name(ref ItemLabelName self) {
+    return std::format("{}", self.Name);
+};
+
+struct GAME_ITEM {
+    u32 Flags; // 0x0
+    s32 PositionIndex; // 0x4
+    s32 ItemCounts[8]; // 0x8
+    s32 LabelLengths[8]; // 0x28
+    ItemLabelName LabelNames[8]; // 0x48
+    s32 ReferredEnumLength; // 0x248
+    char ReferredEnumName[0x40][[format("fmt_fixed_length_string")]]; // 0x24c
+};
+
+struct GAME_AREA_NAME {
+    u32 Flags; // 0x0
+};
+
+struct GAME_MONEY {
+    u32 Flags; // 0x0
+    s32 Money; // 0x4
+    s32 ReferredEnumLength; // 0x8
+    char ReferredEnumName[0x40][[format("fmt_fixed_length_string")]];
+};
+
+struct GAME_NAME_ENTRY {
+    u32 Flags; // 0x0
+};
+
+struct GAME_PLAYER_NAME_ENTRY {
+    u32 Flags; // 0x0
+};
+
+struct GAME_QUEST {
+    u32 Flags; // 0x0
+    s32 TypeIndex; // 0x4
+    s32 LabelLength; // 0x8
+    char LabelName[0x40][[format("fmt_fixed_length_string")]];
+};
+
+struct GAME_SORTIE_MAP {
+    u32 Flags; // 0x0
+    s32 MapZoneIDIndex; // 0x4
+    s32 MapPointId; // 0x8
+};
+
+struct GAME_TUTORIAL {
+    u32 Flags; // 0x0
+    s32 LabelLength; // 0x4
+    char LabelName[0x40][[format("fmt_fixed_length_string")]];
+};
+
+struct MASK_BLEND {
+    u32 Flags; // 0x0
+    s32 BlendMode; // 0x8
+    f32 Alpha; // 0xc
+    vector2 UVPos; // 0x10
+    vector2 UVScale; // 0x18
+    f32 UVRotate; // 0x20
+    s32 TexAddressMode; // 0x24
+    padding[4];
+    f32 UVCenterX; // 0x2c
+    f32 UVCenterY; // 0x30
+};
+
+struct MASK_LAYER_BLEND {
+    u32 Flags; // 0x0
+    s32 MaskId; // 0x4
+    s32 Priority; // 0x8
+    s32 BlendMode; // 0xc
+    f32 Alpha; // 0x10
+    vector2 UVPos; // 0x14
+    vector2 UVScale; // 0x1c
+    f32 UVRotate; // 0x24
+    s32 TexAddressMode; // 0x28
+    padding[4];
+    f32 UVCenterX; // 0x30
+    f32 UVCenterY; // 0x34
+};
+
+struct MESSAGE {
+    u32 Flags; // 0x0
+    u16 MsgLabelMajorID; // 0x4
+    u8 MsgLabelMinorID; // 0x6
+    u8 MsgLabelSubID; // 0x7
+    u16 SelLabelMajorID; // 0x8
+    u8 SelLabelMinorID; // 0xa
+    u8 SelLabelSubID; // 0xb
+    u32 SetResultIndex; // 0xc
+    u16 MsgForceEndWait; // 0x10
+    s32 BustupFaceIndex; // 0x14
+    s32 BustupOptionIndex; // 0x18
+    s32 BustupCostumeIndex; // 0x1c
+    s32 LipSyncModelUID; // 0x20
+    s32 FollowerIndex; // 0x24
+    s32 FollowerFriendship; // 0x28
+};
+
+struct MESSAGE_VOICE {
+    u32 Flags; // 0x0
+    s32 MsgLabelMajorID; // 0x4
+    s32 MsgLabelSubID; // 0x8
+    s32 LipSyncModelUID; // 0xc
+};
+
+struct SUBTITLE {
+    u32 Flags; // 0x0
+    s32 LabelId; // 0x4
+    s32 LabelSubId; // 0x8
+    s32 LipSyncModelUID; // 0xc
+};
+
+struct MOB_ANIM_BASE {
+    u32 Flags; // 0x0
+    s32 AnimNo; // 0x4
+    s32 AnimStartFrame; // 0x8
+    s32 AnimEndFrame; // 0xc
+    s32 AnimBlendFrame; // 0x10
+    s32 AnimFlags; // 0x14
+    f32 AnimSpeed; // 0x18
+    s32 StartIntervalSeed; // 0x1c
+    s32 StartIntervalFrame; // 0x20
+    s32 StartFrameRandomMax; // 0x24
+};
+
+struct MOB_ICON {
+    u32 Flags; // 0x0
+    s32 IconTypeIndex; // 0x4
+    s32 IconSizeIndex; // 0x8
+    f32 Scale; // 0xc
+    vector3 PosOffset; // 0x10
+};
+
+struct MOB_LOOKAT {
+    u32 Flags; // 0x0
+    s32 ControlTypeIndex; // 0x4
+    s32 SpeedTypeIndex; // 0x8
+    vector3 LocalPos; // 0xc
+    s32 StartIntervalSeed; // 0x18
+    s32 StartIntervalFrame; // 0x1c
+};
+
+struct MOB_SET_DIRECT {
+    u32 Flags; // 0x0
+    vector3 Pos; // 0x4
+    euler AngleDeg; // 0x10
+    s32 AnimStartFrameSeed; // 0x20
+    s32 AnimStartFrameOffset; // 0x24
+};
+
+struct MOB_REGISTER {
+    u32 Flags; // 0x0
+    u32 RegisterType; // 0x4
+};
+
+struct MODEL_AEX {
+    u32 Flags; // 0x0
+};
+
+struct MODEL_ALPHA {
+    u32 Flags; // 0x0
+    padding[3];
+    u8 AlphaValue; // 0x7
+    u32 InterpParam; // 0x8
+    u8 TransparencyMode; // 0xc
+};
+
+struct MODEL_ANIM_ADD {
+    u32 TrackNo; // 0x0
+    s32 AnimNo; // 0x4
+    s32 AnimBlendFrame; // 0x8
+    f32 AnimWeight; // 0xc
+    u32 AnimFlags; // 0x10
+    f32 AnimSpeed; // 0x14
+    s32 AnimStartFrame; // 0x18
+    u32 Flags; // 0x1c
+};
+
+struct MODEL_ANIM_BASE {
+    s32 Anim1No; // 0x0
+    s16 Anim1LoopBlendFrame; // 0x4
+    s16 Anim1BlendFrame; // 0x6
+    u32 Anim1Flags; // 0x8
+    f32 Anim1Speed; // 0xc
+    s32 Anim2No; // 0x10
+    s16 Anim2LoopBlendFrame; // 0x14
+    s16 Anim2BlendFrame; // 0x16
+    u32 Anim2Flags; // 0x18
+    f32 Anim2Speed; // 0x1c
+    u32 Flags; // 0x20
+    s32 Anim1StartFrame; // 0x24
+    s32 Anim1EndFrame; // 0x28
+    s32 Anim2StartFrame; // 0x2c
+    s32 Anim2EndFrame; // 0x30
+    s32 Anim1WaitFrame; // 0x34
+};
+
+struct MODEL_ATTACH {
+    u32 Flags; // 0x0
+    u32 HelperID; // 0x4
+    u32 TargetAssetID; // 0x8
+    padding[4];
+    vector3 Pos; // 0x10
+    euler RotDeg; // 0x1c
+    u32 InterpParam; // 0x28
+    vector3 DstPos; // 0x2c
+    euler DstRotDeg; // 0x38
+};
+
+struct MODEL_CLOTH {
+    u32 Flags; // 0x0
+    s32 IterateCount; // 0x4
+};
+
+struct MODEL_CLOTH_ENABLE {
+    u32 Flags; // 0x0
+    u32 PartFlags; // 0x4
+};
+
+struct MODEL_DETACH {
+    u32 Flags; // 0x0
+    u32 HelperID; // 0x4
+    u32 TargetAssetID; // 0x8
+    padding[4];
+    vector3 Pos; // 0x10
+    euler RotDeg; // 0x1c
+    u32 InterpParam; // 0x28
+    vector3 DstPos; // 0x2c
+    euler DstRotDeg; // 0x38
+};
+
+struct MODEL_FACIAL_BLEND {
+    u32 Flags; // 0x0
+    s32 FacialIndex; // 0x4
+    s32 BlendFrame; // 0x8
+    s32 StartFrame; // 0xc
+    s32 RandomSeed; // 0x10
+};
+
+struct MODEL_FOOTSTEPS {
+    u32 Flags; // 0x0
+    s32 FootstepsIndex; // 0x4
+};
+
+struct MODEL_ICON {
+    u32 Flags; // 0x0
+    u32 IconType; // 0x4
+    padding[8];
+    f32 Scale; // 0x10
+    vector3 PosOffset; // 0x14
+};
+
+struct MODEL_ICON_TERMINATE {
+    u32 Flags; // 0x0
+};
+
+struct MODEL_LIPSYNC {
+    u32 Flags; // 0x0
+    f32 MinInterval; // 0x4
+    f32 MaxInterval; // 0x8
+    s32 CtrlTypeIndex; // 0xc
+};
+
+struct MODEL_LOOKAT {
+    u16 Flags; // 0x0
+    u16 MotionFlags; // 0x2
+    u16 MotionType; // 0x4
+    u16 TargetType; // 0x6
+    u16 ResetPhysicsCount; // 0x8
+    u16 SpeedType; // 0xa
+    vector3 TargetPos; // 0xc
+    u32 TargetAssetID; // 0x18
+    u32 TargetHelperID; // 0x1c
+    vector3 HelperOffset; // 0x20
+    f32 VerticalAngle; // 0x2c
+    f32 HorizontalAngle; // 0x30
+};
+
+struct MODEL_MOVE_ANIM {
+    u32 Flags; // 0x0
+    s32 MoveType; // 0x4
+    f32 Speed; // 0x8
+    vector3 StartPos; // 0xc
+    vector3 TargetPos; // 0x18
+    s32 IdleIndex; // 0x24
+};
+
+struct PathPoint {
+    u32 PathType;
+    u32 PointNum;
+    vector3 Positions[24];
+};
+
+
+struct MODEL_MOVE_DIRECT {
+    PathPoint Path;
+    u32 Flags; // 0x128
+    f32 Speed; // 0x12c
+    s32 MoveFrameLength; // 0x130
+    u8 SpeedTypeEarly; // 0x134
+    u8 SpeedTypeLate; // 0x135
+    padding[2];
+    s32 MoveAnimNo; // 0x138
+    s32 MoveAnimBlendFrame; // 0x13c
+    u32 MoveAnimFlags; // 0x140
+    f32 MoveAnimSpeed; // 0x144
+    s32 MoveAnimStartFrame; // 0x148
+    s32 MoveAnimEndFrame; // 0x14c
+    s32 WaitAnimNo; // 0x158
+    s32 WaitAnimBlendFrame; // 0x15c
+    u32 WaitAnimFlags; // 0x160
+    f32 WaitAnimSpeed; // 0x164
+    s32 WaitAnimStartFrame; // 0x168
+    s32 WaitAnimEndFrame; // 0x16c
+};
+
+struct MODEL_MOVE_START_ANIM {
+    u32 Flags; // 0x0
+    s32 MoveType; // 0x4
+    f32 Speed; // 0x8
+    vector3 Pos; // 0xc
+    s32 Count; // 0x18
+    f32 Height; // 0x1c
+    f32 Rotation; // 0x20
+    s32 IdleIndex; // 0x24
+};
+
+struct MODEL_OBJ_DISP {
+    u32 Flags; // 0x0
+    u32 VisibleFlags; // 0x4
+};
+
+struct MODEL_PLANE_GRADATION {
+    u32 Flags; // 0x0
+    vector3 PlanePos; // 0x4
+    f32 PlaneDistance; // 0x10
+    euler PlaneRot; // 0x14
+    f32RGB LightColor; // 0x20
+    f32RGB ShadowColor; // 0x2c
+    f32 Attenuation; // 0x38
+    f32 Factor; // 0x3c
+};
+
+struct MODEL_REGISTER {
+    u32 Flags; // 0x0
+    u32 RegisterType; // 0x4
+    u32 SceneType; // 0x8
+};
+
+struct MODEL_ROTATE {
+    u32 Flags; // 0x0
+    euler AngleDeg; // 0x4
+    u32 InterpParam; // 0x10
+    s32 TurnFrame; // 0x14
+    padding[8];
+    s32 TurnAnimNo; // 0x20
+    s32 TurnAnimBlendFrame; // 0x24
+    u32 TurnAnimFlags; // 0x28
+    f32 TurnAnimSpeed; // 0x2c
+    s32 TurnAnimStartFrame; // 0x30
+    s32 TurnAnimEndFrame; // 0x34
+    padding[8];
+    s32 WaitAnimNo; // 0x40
+    s32 WaitAnimBlendFrame; // 0x44
+    u32 WaitAnimFlags; // 0x48
+    f32 WaitAnimSpeed; // 0x4c
+    s32 WaitAnimStartFrame; // 0x50
+    s32 WaitAnimEndFrame; // 0x54
+};
+
+struct MODEL_SCALE {
+    u32 Flags; // 0x0
+    u32 InterpParam; // 0x4
+    f32 Scale; // 0x8
+};
+
+struct MODEL_SET_DIRECT {
+    vector3 Pos; // 0x0
+    euler AngleDeg; // 0xc
+    s32 WaitAnimNo; // 0x18
+    s32 WaitAnimBlendFrame; // 0x1c
+    u16 WaitAnimFlags; // 0x20
+    f32 WaitAnimSpeed; // 0x24
+    u32 Flags; // 0x28
+    s32 WaitAnimStartFrame; // 0x2c
+    s32 ResetPhysicsCount; // 0x30
+};
+
+struct MODEL_TURN {
+    u32 Flags; // 0x0
+    f32 Speed; // 0x4
+    f32 StartAngle; // 0x8
+    f32 TargetAngle; // 0xc
+};
+
+struct MOVIE_PLAY {
+    u32 Flags; // 0x0
+    f32 FadeIn; // 0x4
+    f32 FadeOut; // 0x8
+};
+
+struct PAD_RUMBLE {
+    u32 Flags; // 0x0
+    u32 TypeIndex; // 0x4
+};
+
+struct PFX_BLUR_RADIAL {
+    u32 Flags; // 0x0
+    u16 FrameLengthIn; // 0x4
+    u16 FrameLengthOut; // 0x6
+    u32 InterpParamIn; // 0x8
+    u32 InterpParamOut; // 0xc
+    vector2 CenterPos; // 0x10
+    f32 Power; // 0x18
+    f32 FallOff; // 0x1c
+    u32 BlendType; // 0x20
+    u8RGBA ColorRGBA; // 0x24
+};
+
+struct PFX_BLUR_STRAIGHT {
+    u32 Flags; // 0x0
+    u16 FrameLengthIn; // 0x4
+    u16 FrameLengthOut; // 0x6
+    u32 InterpParamIn; // 0x8
+    u32 InterpParamOut; // 0xc
+    f32 Direction; // 0x10
+    f32 Power; // 0x14
+    u32 BlendType; // 0x18
+    u8RGBA ColorRGBA; // 0x1c
+};
+
+struct PFX_COLOR_CORRECT {
+    u32 Flags; // 0x0
+    u16 FrameLengthIn; // 0x4
+    u16 FrameLengthOut; // 0x6
+    u32 InterpParamIn; // 0x8
+    u32 InterpParamOut; // 0xc
+    vector2 Pos; // 0x10
+    vector2 Dims; // 0x18
+    f32 Cyan; // 0x20
+    f32 Magenta; // 0x24
+    f32 Yellow; // 0x28
+    f32 Dodge; // 0x2c
+    f32 Burn; // 0x30
+    f32 Alpha; // 0x34
+    u32 TextureAssetID; // 0x38
+};
+
+struct PFX_LENSFLARE {
+    u32 TemplateType; // 0x0
+    vector3 Pos; // 0x4
+    f32 Brightness; // 0x14
+    u32 FilterType; // 0x18
+    bool FilterVisible; // 0x1c
+    bool LightGlowVisible; // 0x1d
+    bool TerminateGlowVisible; // 0x1e
+    bool ZPickerEnable; // 0x1f
+    s32 InterpFrameIn; // 0x20
+    s32 InterpFrameOut; // 0x24
+    u32 InterpParamIn; // 0x28
+    u32 InterpParamOut; // 0x2c
+    u32 Flags; // 0x30
+    u32 AssetID; // 0x34
+    u32 HelperID; // 0x38
+// Struct ColorRGBA; // 0xffff80017b7e9eb7
+};
+
+struct PFX_MONOTONE {
+    u32 Flags; // 0x0
+    vector2 Pos; // 0x4
+    vector2 Dims; // 0xc
+    f32 Alpha; // 0x14
+};
+
+struct SCRIPT {
+u32 Flags; // 0x0
+u32 ScriptFuncNameLength; // 0x4
+char ScriptFuncName[0x40][[format("fmt_fixed_length_string")]];
+};
+
+struct SOUND {
+    u32 Flags; // 0x0
+    s32 SoundType; // 0x4
+    s32 CtrlType; // 0x8
+    s32 PlayerNo; // 0xc
+    s32 CueID; // 0x10
+    f32 Volume; // 0x14
+    f32 FadeOut; // 0x18
+};
+
+struct SOUND_AMBIENT {
+    u32 Flags; // 0x0
+    s32 CtrlType; // 0x4
+    f32 FadeDuration; // 0x8
+};
+
+struct TEXTURE {
+    u32 Flags; // 0x0
+    u16 FrameLengthIn; // 0x4
+    u16 FrameLengthOut; // 0x6
+    u32 InterpParamIn; // 0x8
+    u32 InterpParamOut; // 0xc
+    vector3 Pos; // 0x10
+    vector2 Scale; // 0x1c
+    vector2 U; // 0x24
+    vector2 V; // 0x2c
+    u32 RenderPrio; // 0x34
+    u32 BlendType; // 0x38
+    u8RGBA ColorRGBA; // 0x3c
+};
+
+struct TEX_COLOR_CORRECT {
+    u32 Flags; // 0x0
+    vector2 Pos; // 0x4
+    vector2 Dims; // 0xc
+    f32 Cyan; // 0x14
+    f32 Magenta; // 0x18
+    f32 Yellow; // 0x1c
+    f32 Dodge; // 0x20
+    f32 Burn; // 0x24
+    f32 Alpha; // 0x28
+};
+
+struct FIELD_REGISTER {
+    u32 Flags; // 0x0
+    u32 RegisterType; // 0x4
+};
+
+
+struct WIPE {
+    u32 Flags; // 0x0
+    s32 Action; // 0x4
+    s32 IdIndex; // 0x8
+};
+
+struct ENV_CHARA_LIGHT {
+    u32 Flags;
+    f32 Field04;
+    u32 Field08;
+    f32 Field0C;
+    f32 Field10;
+    f32 Field14;
+    f32 Field18;
+    f32 Field1C;
+    f32 Field20;
+    u32 Field24[0x20];
+    u32 FieldA4;
+    f32 FieldA8;
+};
+
+struct Command {
+    char CommandCode[0x4];
+    u16 CommandVersion;
+    u16 CommandType;
+    u32 AssetID;
+    u32 Flags;
+    u32 FrameStart;
+    u32 FrameLength;
+    u32 CommandParamOfs;
+    u32 CommandParamSize;
+    u32 CondType;
+    u32 CondIndex;
+    u32 CondValue;
+    u32 CondCompType;
+    char CondName[0x40][[format("fmt_fixed_length_string")]];
+    match (CommandCode) {
+        ("CMD_"): CAMERA_MOVE_DIRECT Param @ CommandParamOfs;
+        ("CSA_"): CAMERA_SET_ASSET Param @ CommandParamOfs;
+        ("CSD_"): CAMERA_SET_DIRECT Param @ CommandParamOfs;
+        ("CSF_"): CAMERA_SET_FIELD Param @ CommandParamOfs;
+        ("CShk"): CAMERA_SHAKE Param @ CommandParamOfs;
+        ("Date"): GAME_DATE Param @ CommandParamOfs;
+        ("EAlp"): EFFECT_ALPHA @ CommandParamOfs;
+        ("EnBc"): ENV_BGCOLOR @ CommandParamOfs;
+        ("EnC_"): ENV_CLOUD Param @ CommandParamOfs;
+        ("EnCc"): ENV_CORRECT @ CommandParamOfs;
+        ("EnCL"): ENV_CHARA_LIGHT @ CommandParamOfs;
+        ("EnDf"): ENV_DOF @ CommandParamOfs;
+        ("EnDi"): ENV_DIFFUSION @ CommandParamOfs;
+        ("Enef"): ENV_EXPONENTIAL_FOG @ CommandParamOfs;
+        ("EnHd"): ENV_HDR @ CommandParamOfs;
+        ("EnL0"): ENV_LIGHT_0 @ CommandParamOfs;
+        ("EnL1"): ENV_LIGHT_1 @ CommandParamOfs;
+        ("EnOl"): ENV_OUTLINE @ CommandParamOfs;
+        ("EnPg"): ENV_PLANE_GRADATION @ CommandParamOfs;
+        ("EnPh"): ENV_PHYSICS @ CommandParamOfs;
+        ("EnSD"): ENV_SKYDOME @ CommandParamOfs;
+        ("EnSh"): ENV_SHADOW @ CommandParamOfs;
+        ("EnSs"): ENV_SSAO @ CommandParamOfs;
+        ("Env_"): ENV_SET @ CommandParamOfs;
+        ("ERgs"): EFFECT_REGISTER @ CommandParamOfs;
+        ("EScl"): EFFECT_SCALE @ CommandParamOfs;
+        ("ESD_"): EFFECT_SET_DIRECT @ CommandParamOfs;
+        ("ESH_"): EFFECT_SET_HELPER @ CommandParamOfs;
+        ("FAB_"): FIELD_OBJ_ANIM_BASE @ CommandParamOfs;
+        ("Fd__"): FADE @ CommandParamOfs;
+        ("FFD_"): FIELD_FEATURE_DISP @ CommandParamOfs;
+        ("FL__"): FIELD_LIGHTS @ CommandParamOfs;
+        ("FMD_"): FIELD_MOB_DISP @ CommandParamOfs;
+        ("FMDB"): FIELD_MOB_DISP_BOX @ CommandParamOfs;
+        ("FOD_"): FIELD_OBJ_DISP @ CommandParamOfs;
+        ("FR__"): FIELD_REGISTER @ CommandParamOfs;
+        ("FrJ_"): FRAME_JUMP @ CommandParamOfs;
+        ("Frus"): FRAME_UNSKIPPABLE @ CommandParamOfs;
+        ("FS__"): FIELD_SET @ CommandParamOfs;
+        ("GAn_"): GAME_AREA_NAME @ CommandParamOfs;
+        ("GBpu"): GAME_BASE_PARAM_UP @ CommandParamOfs;
+        ("GCAP"): GAME_FOLLOWER_RANK_UP @ CommandParamOfs;
+        ("GHpu"): GAME_HUMAN_PARAM_UP @ CommandParamOfs;
+        ("GI__"): GAME_ITEM @ CommandParamOfs;
+        ("GM__"): GAME_MONEY @ CommandParamOfs;
+        ("GNe_"): GAME_NAME_ENTRY @ CommandParamOfs;
+        ("GPne"): GAME_PLAYER_NAME_ENTRY @ CommandParamOfs;
+        ("GQ__"): GAME_QUEST @ CommandParamOfs;
+        ("GSm_"): GAME_SORTIE_MAP @ CommandParamOfs;
+        ("GTut"): GAME_TUTORIAL @ CommandParamOfs;
+        ("MAA_"): MODEL_ANIM_ADD @ CommandParamOfs;
+        ("MAB_"): MODEL_ANIM_BASE @ CommandParamOfs;
+        ("MAex"): MODEL_AEX @ CommandParamOfs;
+        ("MAlp"): MODEL_ALPHA @ CommandParamOfs;
+        ("MAt_"): MODEL_ATTACH @ CommandParamOfs;
+        ("Mbab"): MOB_ANIM_BASE @ CommandParamOfs;
+        ("Mbic"): MOB_ICON @ CommandParamOfs;
+        ("Mbla"): MOB_LOOKAT @ CommandParamOfs;
+        ("Mbr_"): MOB_REGISTER @ CommandParamOfs;
+        ("Mbsd"): MOB_SET_DIRECT @ CommandParamOfs;
+        ("MCe_"): MODEL_CLOTH_ENABLE @ CommandParamOfs;
+        ("MCPr"): MODEL_CLOTH @ CommandParamOfs;
+        ("MDt_"): MODEL_DETACH @ CommandParamOfs;
+        ("MFb_"): MODEL_FACIAL_BLEND @ CommandParamOfs;
+        ("MFs_"): MODEL_FOOTSTEPS @ CommandParamOfs;
+        ("MIc_"): MODEL_ICON @ CommandParamOfs;
+        ("MIct"): MODEL_ICON_TERMINATE @ CommandParamOfs;
+        ("MLa_"): MODEL_LOOKAT @ CommandParamOfs;
+        ("MLs_"): MODEL_LIPSYNC @ CommandParamOfs;
+        ("Mma_"): MODEL_MOVE_ANIM @ CommandParamOfs;
+        ("MMD_"): MODEL_MOVE_DIRECT @ CommandParamOfs;
+        ("Mmsa"): MODEL_MOVE_START_ANIM @ CommandParamOfs;
+        ("MOD_"): MODEL_OBJ_DISP @ CommandParamOfs;
+        ("MPg_"): MODEL_PLANE_GRADATION @ CommandParamOfs;
+        ("MRgs"): MODEL_REGISTER @ CommandParamOfs;
+        ("MRot"): MODEL_ROTATE @ CommandParamOfs;
+        ("MScl"): MODEL_SCALE @ CommandParamOfs;
+        ("MSD_"): MODEL_SET_DIRECT @ CommandParamOfs;
+        ("Msg_"): MESSAGE @ CommandParamOfs;
+        ("MsgV"): MESSAGE_VOICE @ CommandParamOfs;
+        ("mskb"): MASK_BLEND @ CommandParamOfs;
+        ("mskl"): MASK_LAYER_BLEND @ CommandParamOfs;
+        ("MTr_"): MODEL_TURN @ CommandParamOfs;
+        ("MvPl"): MOVIE_PLAY @ CommandParamOfs;
+        ("PBRd"): PFX_BLUR_RADIAL @ CommandParamOfs;
+        ("PBSt"): PFX_BLUR_STRAIGHT @ CommandParamOfs;
+        ("PCc_"): PFX_COLOR_CORRECT @ CommandParamOfs;
+        ("PLf_"): PFX_LENSFLARE @ CommandParamOfs;
+        ("PMn_"): PFX_MONOTONE @ CommandParamOfs;
+        ("PRum"): PAD_RUMBLE @ CommandParamOfs;
+        ("Scr_"): SCRIPT @ CommandParamOfs;
+        ("Snd_"): SOUND @ CommandParamOfs;
+        ("SndA"): SOUND_AMBIENT @ CommandParamOfs;
+        ("Subs"): SUBTITLE @ CommandParamOfs;
+        ("TCc_"): TEX_COLOR_CORRECT @ CommandParamOfs;
+        ("Tex_"): TEXTURE @ CommandParamOfs;
+        ("Wp__"): WIPE @ CommandParamOfs;
+    }
+}[[format("fmt_command")]];//[[name(std::format("{}", CommandCode))]];
+
+fn fmt_command(ref Command self) {
+    return std::format("{}: ASSET: {}, FRAME: {}-{}", self.CommandCode, self.AssetID, self.FrameStart, self.FrameStart + self.FrameLength);
+};
+
+enum FileType : u8 {
+    Evt = 0,
+    Ecs = 1,
+    Unk = 2
+};
+
+fn get_file_type() {
+    str ext = std::string::substr(std::string::to_lower(hex::prv::get_information("file_extension")), 1, 3);
+    match (ext) {
+        ("evt"): return FileType::Evt;
+        ("ecs"): return FileType::Ecs;
+        (_): return FileType::Unk;
+    }
+};
+
+struct Evt {
+    FileType file = get_file_type();
+    match (file) {
+        (FileType::Evt): EvtHeader header;
+        (FileType::Ecs): EcsHeader header;
+    }
+    std::assert(file != FileType::Unk, "Unsupported filetype for this template");
+    if (file == FileType::Evt) {
+        Object object[header.AssetNums];
+    }
+    Command commands[header.CommandNums];
+    if (file == FileType::Evt) {
+        if (header.MessagePathOfs > 0) {
+            char MessagePath[header.MessagePathSize] @ header.MessagePathOfs[[format("fmt_fixed_length_string")]];
+        }
+        if (header.ScriptPathOfs > 0) {
+            char ScriptPath[header.ScriptPathSize] @ header.ScriptPathOfs[[format("fmt_fixed_length_string")]];
+        }
+    }
+};
+
+Evt evt @ 0x00[[inline]];

--- a/p5r/common/numerics.expat
+++ b/p5r/common/numerics.expat
@@ -17,6 +17,27 @@ fn fmt_vector3(ref vector3 self) {
     return std::format("x: {}, y: {}, z: {}", self.x, self.y, self.z);
 };
 
+struct vector4 {
+    float x;
+    float y;
+    float z;
+    float w;
+}[[format("fmt_vector4")]];
+
+fn fmt_vector4(ref vector4 self) { 
+    return std::format("x: {}, y: {}, z: {}, w: {}", self.x, self.y, self.z, self.w); 
+};
+
+struct euler {
+    float yaw;
+    float pitch;
+    float roll;
+}[[format("fmt_euler")]];
+
+fn fmt_euler(ref euler self) { 
+    return std::format("yaw: {}, pitch: {}, roll: {}", self.yaw, self.pitch, self.roll); 
+};
+
 struct quaternion {
     float x;
     float y;

--- a/p5r/savefile.hexpat
+++ b/p5r/savefile.hexpat
@@ -1,0 +1,938 @@
+#pragma author Rirurin
+#pragma description Template for decrypted saves from Persona 5 Royal (2022 multiplatform release)
+// Header structures from https://github.com/zarroboogs/fiber-saveutil
+
+
+//#define LOAD_ANALYSIS_DATA // Bitfields that aren't aligned to a byte boundary are quite slow since they can't be optimized
+
+#include <std/array.pat>
+#include <std/mem.pat>
+#include <std/io.pat>
+#include <atlus/p5r/common/numerics.expat>
+
+struct EncryptInfo {
+    char signature[4];
+    u32 crc;
+    u32 timestamp;
+    u32 flags;
+    u128 iv[[hidden]]; // always zero
+}[[format("fmt_encryptinfo")]];
+fn fmt_encryptinfo(ref EncryptInfo self) { return std::format("CRC 0x{:X}, TIME 0x{:X}", self.crc, self.timestamp); };
+
+struct DataInfo {
+    u16 head_size;
+    u16 head_size_cmp[[hidden]]; // always zero
+    u32 data_size;
+    u32 data_size_cmp[[hidden]]; // always zero
+    u32 flags;
+    u32 crc;
+    padding[12];
+}[[format("fmt_datainfo")]];
+fn fmt_datainfo(ref DataInfo self) { return std::format("CRC 0x{:X}, FLAGS 0x{:X}", self.crc, self.flags); };
+
+enum TimeOfDay : u8 {
+    EarlyMorning = 0,
+    Morning = 1,
+    Lunchtime = 2,
+    Daytime = 3,
+    AfterSchool = 4,
+    Evening = 5,
+    LateNight = 6
+};
+
+enum Difficulty : u8 {
+    Safe = 0,
+    Easy = 1,
+    Normal = 2,
+    Hard = 3,
+    Merciless = 4
+};
+
+struct DataHeader {
+    u32 playtime_frames[[format("fmt_playtime")]];
+    s16 day[[format("fmt_day")]]; // days since April 1
+    TimeOfDay time;
+    u8 playthrough; // Normal/NG+ ? (can't check i don't have a ng+ save)
+    Difficulty difficulty;
+    u8 level;
+    u8 clear;
+    padding[1];
+    u8 fld_major;
+    u8 fld_minor;
+    u8 lang0;
+    u8 lang1;
+    char last_name[64][[sealed]]; // utf8
+    char first_name[64][[sealed]]; // utf8
+    char description[256]; // ascii
+}[[format("fmt_dataheader")]];
+
+fn fmt_playtime(u32 self) {
+    u32 seconds = self / 30;
+    u32 sec_disp = seconds % 60;
+    u32 min_disp = (seconds / 60) % 60;
+    u32 hour_disp = (seconds / 3600);
+    return std::format("{:02d}:{:02d}:{:02d}", hour_disp, min_disp, sec_disp);
+};
+
+u32 days_per_month[12];
+days_per_month[0] = 30; // april
+days_per_month[1] = 31; // may
+days_per_month[2] = 30; // june
+days_per_month[3] = 31; // july
+days_per_month[4] = 31; // august
+days_per_month[5] = 30; // september
+days_per_month[6] = 31; // october
+days_per_month[7] = 30; // november
+days_per_month[8] = 31; // december
+days_per_month[9] = 31; // january
+days_per_month[10] = 28; // february (2017)
+days_per_month[11] = 30; // march
+
+fn fmt_day(s16 self) {
+    u8 month = 0;
+    while (s16(self - days_per_month[month]) > 0) {
+        self -= days_per_month[month];
+        month += 1;
+    }
+    month = (month + 3) % 12;
+    return std::format("{}/{}", month + 1, self + 1);
+};
+
+fn fmt_dataheader(ref DataHeader self) {
+    return std::format(
+        "{} @ f{:03}_{:03}, {}", 
+        fmt_day(self.day), self.fld_major, self.fld_minor, fmt_playtime(self.playtime_frames)
+    );
+};
+
+struct DataVersion {
+    u32 version;
+    padding[12];
+}[[format("fmt_dataversion")]];
+fn fmt_dataversion(ref DataVersion self) { return std::format("version {}", self.version); };
+
+fn read_u8(u32 addr) {
+    u8 value @ addr;
+    return value;
+};
+
+fn read_u16(u32 addr) {
+    u16 value @ addr;
+    return value;
+};
+
+fn read_u32(u32 addr) {
+    u32 value @ addr;
+    return value;
+};
+
+fn read_u64(u32 addr) {
+    u64 value @ addr;
+    return value;
+};
+
+// Save data blocks
+
+// mv::savedata::gamedata::v39_new::DataBlockPlayer<49>
+enum PlayerId : u32 {
+    Player = 1,
+    Ryuji = 2,
+    Morgana = 3,
+    Ann = 4,
+    Yusuke = 5,
+    Makoto = 6,
+    Haru = 7,
+    Futaba = 8,
+    Akechi = 9,
+    Kasumi = 10
+};
+
+enum PIDShort : u16 {
+    Player = 1,
+    Ryuji = 2,
+    Morgana = 3,
+    Ann = 4,
+    Yusuke = 5,
+    Makoto = 6,
+    Haru = 7,
+    Futaba = 8,
+    Akechi = 9,
+    Kasumi = 10
+};
+
+struct PersonaStats {
+    u8 strength;
+    u8 magic;
+    u8 endurance;
+    u8 agility;
+    u8 luck;
+};
+struct DatPersona {
+    u8 flags;
+    u8 unlocked;
+    u16 id;
+    u8 level;
+    u8 inherit;
+    u8 trait;
+    padding[1];
+    u32 exp;
+    u16 skill[8];
+    PersonaStats stats;
+    PersonaStats stats_ex;
+    PersonaStats stats_ex_temp;
+    u32 field_3b;
+    u8 field_3f;
+}[[static, format("fmt_persona")]];
+fn fmt_persona(ref DatPersona self) { return std::format("ID {}, LEVEL {}, EXP {}", self.id, self.level, self.exp); };
+struct DatItem {
+    u16 melee_id;
+    u16 protect_id;
+    u16 accessory_id;
+    u16 outfit_id;
+    u16 ranged_id;
+};
+struct DatUnit {
+    u32 flags; // @ 0x0
+    u16 type; // @ 0x4
+    padding[2]; // @ 0x6
+    PlayerId id; // @ 0x8
+    u32 hp; // @ 0xc
+    u32 sp; // @ 0x10
+    u32 ailments; // @ 0x14
+    u16 joker_lvl; // @ 0x18
+    padding[2];
+    u32 joker_exp; // @ 0x1c
+    u32 affinity; // @ 0x20
+    u32 buffs; // @ 0x24
+    u32 buffs2; // @ 0x28
+    u8 buff_type[10]; // @ 0x2c
+    u16 field_36;; // @ 0x36
+    u32 field_38; // @ 0x38
+    u32 field_3c; // @ 0x3c
+    u16 curr_persona_idx; // @ 0x40
+    padding[2];
+    DatPersona persona[12]; // @ 0x44
+    DatItem items; // @ 0x284
+    padding[4];
+    u16 tactics_state; // @ 0x292
+    u16 bullet_count; // @ 0x294
+    u16 hit_status; // @ 0x296
+    u32 ref_count; // @ 0x298
+    u16 hp_next_lv; // @ 0x29c
+    u16 sp_next_lv; // @ 0x29c
+}[[static, format("fmt_datunit")]];
+fn get_player_level(ref DatUnit self) {
+    if (self.id == PlayerId::Player) return self.joker_lvl;
+    return self.persona[0].level;
+};
+fn fmt_datunit(ref DatUnit self) { return std::format("{}, LV {}, HP {}, SP {}", self.id, get_player_level(self), self.hp, self.sp); };
+// mv::savedata::gamedata::v39_new::DataBlockParty<49>
+struct DataBlockParty {
+    u16 active_party_ids[10];
+    std::mem::AlignTo<0x10> align;
+};
+fn fmt_party(ref DataBlockParty data) {
+    u32 curr_addr = addressof(data);
+    str party = "Active Party: [ ";
+    PIDShort curr_member = read_u16(curr_addr);
+    while (curr_member != 0) {
+        party += std::format("{}", curr_member);
+        curr_addr += 2;
+        curr_member = read_u16(curr_addr);
+        if (curr_member != 0) party += ", ";
+    }
+    party += " ]";
+    return party;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockItemBag<49>
+struct ItemBag {
+    u8 melee_counts[1024];
+    u8 armor_counts[1024];
+    u8 accessory_counts[512];
+    u8 consumable_counts[1024];
+    u8 key_item_counts[256];
+    u8 material_counts[1024];
+    u8 skill_card_counts[1024];
+    u8 outfit_counts[512];
+    u8 ranged_counts[256];
+    u8 field_1a00[128];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockMoney<49>
+struct Money {
+    u32 money;
+    std::mem::AlignTo<0x10> align;
+}[[format("fmt_money")]];
+fn fmt_money(ref Money self) { return std::format("¥{}", self.money); };
+
+// mv::savedata::gamedata::v39_new::DataBlockFlag<49>
+struct Bitflags {
+    u8 section0[384];
+    u8 section1[384];
+    u8 section2[640];
+    u8 section3[64];
+    u8 section4[64];
+    u8 section5[64];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockCounter<49>
+struct Counts {
+    u32 counts[384][[inline]];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockPersonaWork<49>
+struct PersonaWork {
+    DatPersona persona[464][[inline]];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockAnalyze<49>
+bitfield EnemyAffinityVisible {
+    KnowPhysical : 1;
+    KnowGun : 1;
+    KnowFire : 1;
+    KnowIce : 1;
+    KnowElectric : 1;
+    KnowWind : 1;
+    KnowPsychic : 1;
+    KnowNuclear : 1;
+    KnowBless : 1;
+    KnowCurse : 1;
+    KnowAlmighty: 1;
+};
+struct AnalysisData {
+    #ifdef LOAD_ANALYSIS_DATA
+        EnemyAffinityVisible affinity_visible[783]; // 1077 bytes
+        padding[3];
+        u8 knows_item_reward[100]; // 800 bitflags, used when Shadow Calculus (Makoto Rank 1) isn't yet unlocked
+        EnemyAffinityVisible ai_act_multitarget[783];
+        padding[3];
+        EnemyAffinityVisible ai_act_singletarget[783];
+        padding[3];
+    #endif
+    #ifndef LOAD_ANALYSIS_DATA
+        u8 affinity_visible[1080][[sealed]];
+        u8 knows_item_reward[100];
+        u8 ai_act_multitarget[1080][[sealed]];
+        u8 ai_act_singletarget[1080][[sealed]];
+    #endif
+    u32 field_d0c;
+};
+
+// mv::savedata::gamedata::v40::DataBlockCalendar_work<49>
+struct CalendarWork {
+    s16 days_since_april1[[format("fmt_day")]];
+    TimeOfDay time_of_day;
+    padding[1];
+    u16 next_timeskip_day[[format("fmt_day")]];
+    TimeOfDay next_timeskip_time;
+    std::mem::AlignTo<0x10> align;
+}[[format("fmt_calendar")]];
+fn fmt_calendar(ref CalendarWork self) { return std::format("{}, {}", fmt_day(self.days_since_april1), self.time_of_day); };
+
+// mv::savedata::gamedata::v39_new::DataBlockP5ShopData<49>
+struct ShopData {
+    u8 inner[36864][[sealed]];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockCmmWork<49>
+struct CmmDataEntry {
+    u16 field_00;
+    u16 flags;
+    u16 arcana;
+    u16 lvl;
+    u16 points;
+    u16 invites;
+    u16 field_0c;
+    u16 field_0e;
+}[[static, format("fmt_cmmdataentry")]];
+fn fmt_cmmdataentry(ref CmmDataEntry self) { return std::format("Arcana {}, Level {}, Points {}", self.arcana, self.lvl, self.points); };
+
+struct CommunityData {
+    u16 promise;
+    CmmDataEntry entries[24][[inline]];
+    u16 field_182;
+    u32 arbeit_pay;
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v42::DataBlockHeroName<49>
+struct PlayerName {
+    u8 player_name[104][[sealed]]; // utf8
+    u8 last_name[52][[sealed]]; // utf8
+    u8 first_name[52][[sealed]]; // utf8
+    u8 field_d0[20][[sealed]];
+    u8 field_e4[20][[sealed]];
+    u8 field_f8[40][[sealed]];
+    u8 field_120[28][[sealed]];
+    u8 phantom_theives_name[76][[sealed]]; // utf8
+    padding[1];
+    u8 language;
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockPcParam<49>
+struct PlayerCharacterParam {
+    u16 knowledge;
+    u16 charm;
+    u16 proficiency;
+    u16 guts;
+    u16 kindness;
+    std::mem::AlignTo<0x10> align;
+}[[format("fmt_pc_param")]];
+fn fmt_pc_param(ref PlayerCharacterParam self) { return std::format(
+    "{} knowledge, {} charm, {} proficiency, {} guts, {} kindness", 
+    self.knowledge, self.charm, self.proficiency, self.guts, self.kindness
+); };
+
+// mv::savedata::gamedata::v39_new::DataBlockFldSaveCallParam<49>
+struct FieldInfo {
+    u16 fld_major;
+    u16 fld_minor;
+    u16 fld_sub;
+    u16 env_id;
+    vector3 pc_pos;
+    vector4 pc_rot;
+    padding[8];
+    u16 fld_at_dng_pack_list;
+    u16 fld_at_dng_pack_entry;
+}[[format("fmt_fieldinfo")]];
+fn fmt_fieldinfo(ref FieldInfo self) { return std::format("f{:03d}_{:03d}_{:02d} @ {}", self.fld_major, self.fld_minor, self.fld_sub, self.pc_pos); };
+
+// mv::savedata::gamedata::v39_new::DataBlockFldSaveLog<49>
+struct FieldLogEntry {
+    u16 fld_major;
+    u16 fld_minor;
+    u32 times_visited;
+}[[static, format("fmt_fieldlogentry")]];
+fn fmt_fieldlogentry(ref FieldLogEntry self) { return std::format("f{:03d}_{:03d}, visited {} times", self.fld_major, self.fld_minor, self.times_visited); } ;
+
+struct FieldSaveLog {
+    FieldLogEntry visited_fields[0x40][[inline]];
+    u8 unk[0x40];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockQuest<49>
+enum QuestStatus : u8 {
+    Blank = 0,
+    Unknown,
+    Identified_UseDesc0,
+    Identified_UseDesc1,
+    Identified_UseDesc2,
+    Done
+};
+struct QuestEntry {
+    u8 flags;
+    QuestStatus status;
+    u16 field_02;
+    u8 field_04;
+    padding[3];
+}[[static, format("fmt_quest_entry")]];
+fn fmt_quest_entry(ref QuestEntry self) { return std::format("{}", self.status); };
+struct Quest {
+    u32 known_quest_count; // Includes known but unidentified, identified and completed
+    QuestEntry quests[100][[inline]];
+    std::mem::AlignTo<0x10> align;
+}[[format("fmt_quest")]];
+fn fmt_quest(ref Quest self) { return std::format("{} known quests", self.known_quest_count); };
+
+// mv::savedata::gamedata::v39_new::DataBlockFclPublicShop<49>
+struct PublicShopEntry {
+    u8 unk[0x3c][[sealed]];
+    u8 item_quantity[0x1e];
+    u8 field_5a;
+    u8 field_5b;
+    bool known_item[0x1e]; // when 0, a new! will be listed for the item
+}[[static]];
+
+struct PublicShop {
+    PublicShopEntry shops[100][[inline]]; // matches with shop id as seen in fclPublicShopDataTable, fclPublicShopName etc.
+    std::mem::AlignTo<0x10> align; // shop ids 89 - 99 are unused
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockChat<49>
+enum ChatFlags : u8 {
+    None = 0,
+    Read = 1 << 0,
+    Switch = 1 << 1,
+    Hold = 1 << 2,
+    New = 1 << 3
+};
+struct ChatEntry {
+    ChatFlags flags;
+    u8 appear_month;
+    u8 appear_day;
+    padding[5];
+    u16 msg_id;
+    u16 msg_recv_idx;
+    u16 field_0c;
+    u16 field_0e;
+}[[static, format("fmt_chatentry")]];
+fn fmt_chatentry(ref ChatEntry self) { return std::format("ID {}, STAT {}, APPEAR {}/{}", self.msg_id, self.flags, self.appear_month, self.appear_day); };
+
+struct Chat {
+    u16 unk[4];
+    u8 chk_arrival[128];
+    ChatEntry chats[50];
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockSystemWork<49>
+struct SystemWork {
+    u32 frames[[format("fmt_playtime")]];
+    std::mem::AlignTo<0x10> align;
+}[[format("fmt_systemwork")]];
+fn fmt_systemwork(ref SystemWork self) { return std::format("{}", fmt_playtime(self.frames)); };
+
+// mv::savedata::gamedata::v39_new::DataBlockNpcFlag<49>
+struct NpcFlags {
+    u8 flags[100];
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockFldSaveData<49>
+bitfield MementosAreaProgress {
+    areas : 8;
+    unlocked : 1;
+    padding : 7;
+}[[static]];
+struct FieldSaveData {
+    MementosAreaProgress mementos_paths[10];
+    u32 field_14;
+    u8 palace_portrait_id;
+    u8 last_palace_id;
+    u8 unk[38];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockCmmBookWork<49>
+struct BookWork {
+    u32 pages_read[128];
+    bool finished_reading[128];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockNpcQuestOrder<49>
+struct QuestOrder {
+    u8 inner[0x50];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockNetVoice<49>
+struct NetVoice {
+    u8 inner[0x20];
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockArbeitManager<49>
+struct ArbeitManager {
+    u8 inner[44];
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockTrophyWork<49>
+struct TrophyManager {
+    u8 inner[136];
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::gamedata::v39_new::DataBlockBuyItemMainWork<49>
+struct ItemMainWork {
+    u8 inner[484];
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockFldMissionListWork<49>
+struct FieldMissionListWork {
+    u8 inner[288];
+};
+// mv::savedata::gamedata::v40::DataBlockCursorMemory<49>
+struct CursorMemoryPlayer {
+    u16 persona_id;
+    u16 skill_id;
+    padding[8];
+}[[static]];
+
+struct CursorMemory {
+    CursorMemoryPlayer player_params[11];
+    u16 item_id;
+    padding[2];
+    u32 item_sel;
+    u32 item_sel_pad;
+};
+// mv::savedata::gamedata::v39_new::DataBlockFldCasinoWork<49>
+struct FieldCasinoWork {
+    u32 entries[20][[inline]];
+};
+// mv::savedata::gamedata::v39_new::DataBlockSndAppBgmWork<49>
+struct SoundBgmWork {
+    u32 field_00;
+    u32 field_04;
+    u16 field_08;
+    u8 field_0a;
+    u8 field_0b;
+    u32 field_0c;
+};
+// mv::savedata::gamedata::v39_new::DataBlockDiary<49>
+struct DiaryEntry {
+    u8 activity0; // Value used refers to the index in cmmNetReportTable.ctd
+    u8 activity1;
+}[[static]];
+
+struct Diary {
+    DiaryEntry entry[365][[inline]]; // Daily Log entries in Camp menu Calendar
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::gamedata::v39_new::DataBlockFldSaveATDngStamp<49>
+struct MementosStampPack {
+    u16 field_00;
+    padding[2];
+    u8 field_04;
+    padding[3];
+}[[static]];
+
+struct JoseStampData {
+    MementosStampPack stamp_packs[8];
+    padding[14];
+    u16 exp_boost;
+    u16 money_boost;
+    u16 item_boost;
+    padding[10];
+    u32 coin_count;
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::gamedata::v39_new::DataBlockCustomData<49>
+struct GunCustomData {
+    u8 inner[256][[inline]];
+};
+// mv::savedata::gamedata::v39_new::DataBlockFclCombineSaveData<49>
+struct VelvetRoomSaveData {
+    u8 inner[102];
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::gamedata::v39_new::DataBlockFclMementosShop<49>
+struct MementosShop {
+    u8 inner[412];
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::gamedata::v39_new::DataBlockCmpSkillCard<49>
+struct SkillCard {
+    u8 inner[128];
+};
+// mv::savedata::gamedata::v39_new::DataBlockChallengeBtl<49>
+struct ChallengeEntry {
+    u32 high_score;
+    padding[2];
+    u16 rewards_done; // bitflags (0x1 - first reward, 0x2 - second reward, 0x4 - third reward)
+}[[static]];
+
+struct ChallengeBattle {
+    ChallengeEntry battles[16][[inline]];
+};
+// mv::savedata::gamedata::v39_new::DataBlockCmpPcData<49>
+struct PlayerCharacterData {
+    u32 inner[12][[inline]];
+    std::mem::AlignTo<0x10> align;
+};
+
+// mv::savedata::gamedata::v39_new::DataBlockBtlPlayLog<49>
+struct BattlePlayLog {
+    u32 inner[16][[inline]];
+};
+
+// System data blocks
+
+// mv::savedata::sysdata::v2_new::DataBlockSysFlag<7>
+struct SystemFlags {
+    u8 flags[64];
+};
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceItem<7>
+// mypItemDataTable.mtd
+struct ThievesDenItemPlacedEntry {
+    u16 item_id;
+    u8 unk[14];
+}[[static]];
+
+struct ThievesDenItems {
+    ThievesDenItemPlacedEntry placed_items[16];
+    u8 place_item_menu_known[12]; // bitflags for 96 items, 58 used in game
+    u8 buy_item_menu_known[12];
+    u8 field_118[12];
+    u8 place_item_menu_new[12];
+    u8 buy_item_menu_new[12];
+    u32 item_npc_data[80];
+    u8 decor_type;
+    padding[3];
+};
+// mv::savedata::sysdata::v2_new::DataBlockThiefPoint<7>
+struct ThievesDenPoints {
+    u32 points;
+    std::mem::AlignTo<0x10> align;
+}[[format("fmt_thievesden_points")]];
+fn fmt_thievesden_points(ref ThievesDenPoints self) { return std::format("P {}", self.points); };
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceVideo<7>
+struct ThievesDenVideo {
+    u8 is_owned[0x10]; // bitflag for each video (according to order of videos in mypVideoDataTable.mtd
+    u8 is_known[0x10];
+    u8 is_unlocked[0x10];
+    u8 field_30[0x10];
+    u8 is_new[0x10];
+};
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceSound<7>
+struct ThievesDenMusic {
+    u8 music_bought[0x14];
+    u8 music_known[0x14];
+    u8 field_28[0x14];
+    u8 music_previewed[0x14];
+    u8 music_not_new[0x14];
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceImage<7>
+struct ThievesDenImage {
+    u8 image_bought[0x1c];
+    u8 image_known[0x1c];
+    u8 field_38[0x1c];
+    u8 image_previewed[0x1c];
+    u8 image_not_new[0x1c];
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceAward<7>
+struct ThievesDenAward {
+    u32 award_progress[80];
+    u8 unk[0x2440][[sealed]];
+    u8 awards_completed[12]; // bitflags
+    u8 field_2598[12];
+    u8 unk2[0x18][[sealed]];
+};
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceEnv<7>
+struct ThievesDenENV {
+    u32 field_00;
+    u8 env_known[4];
+    u8 field_0c[4];
+    u8 field_10[4];
+    u8 env_not_new[4];
+    std::mem::AlignTo<0x10> align;
+};
+// mv::savedata::sysdata::v2_new::DataBlockMyPalaceCareerPoker<7>
+struct TycoonPlacement {
+    u32 tycoon;
+    u32 rich;
+    u32 poor;
+    u32 beggar;
+};
+struct TycoonData {
+    padding[32];
+    u8 settings[16]; // settings bitflags
+    TycoonPlacement casual;
+    TycoonPlacement serious;
+    TycoonPlacement cutthroat;
+    padding[208];
+    u8 challenges[16]; // challenges completed bitflags
+    
+};
+// mv::savedata::sysdata::v4::DataBlockKeyAssign<7>
+struct KeyboardKeys {
+    // this uses Hedgehog Engine Input keycodes
+    // A translation to Direct Input Keycodes is available at g_keyboardmgr->KeyboardWin32->HHToDIKCodes
+    // [[142a8bbf8] + 60] + 5c8 in Cheat Engine
+    u32 entries[8];
+}[[static]];
+
+struct KeyAssign {
+    u16 controller_keys[0x80];
+    KeyboardKeys keyboard_keys[0x80];
+    u8 unk[0x800];
+};
+// mv::savedata::sysdata::v5::DataBlockActivity<7>
+// mv::savedata::sysdata::v5::DataBlockSaveloadWindow<7>
+// mv::savedata::sysdata::v6::DataBlockConfigOption<7>
+
+bitfield ConfigOptionFlags {
+    Flag0 : 1;
+    Vibration : 1;
+    DialogueVoices : 1;
+    AutoAdvance : 1;
+    AnimationSubtitles : 1;
+    MaintainFastForward : 1;
+    CursorMemory : 1;
+    BattleMemory : 1;
+    PersonaMemory : 1;
+    CamHorizontalInvert : 1;
+    CamVerticalInvert : 1;
+    CameraShake : 1;
+    CameraAutoAdjust : 1;
+    CamAdjustOnCover : 1;
+    RotateMinimapWithCamera : 1;
+    JapaneseVoices : 1;
+    Flag16 : 1;
+    EnableVSync : 1;
+    Flag18 : 1;
+    Flag19 : 1;
+    Flag20 : 1;
+    Flag21 : 1;
+    Flag22 : 1;
+    Flag23 : 1;
+    Flag24 : 1;
+    Flag25 : 1;
+    Flag26 : 1;
+    Flag27 : 1;
+    Flag28 : 1;
+    Flag29 : 1;
+    Flag30 : 1;
+    Flag31 : 1;
+};
+
+struct ConfigOptions {
+    u8 mouse_sense;
+    u8 control_sense;
+    u8 button_display;
+    u8 main_volume;
+    u8 bgm_volume;
+    u8 se_volume;
+    u8 voice_volume;
+    u8 movie_volume;
+    u8 graphic_quality;
+    u8 shadow_quality;
+    u8 antialias;
+    u8 dof_level;
+    padding[4];
+    u16 render_scale;
+    u16 fps_limit;
+    ConfigOptionFlags flags;
+    u32 width;
+    u32 height;
+    padding[8];
+    u16 screen_dimness;
+    padding[2];
+    u8 cam_speed;
+    std::mem::AlignTo<0x10> align;
+};
+
+// 0x14809c7f0
+struct DataBlock {
+    u32 block_id;
+    u32 size;
+    padding[8];
+    match (block_id) {
+        (0x10001 ... 0x1000A): DatUnit data;
+        (0x18001 ... 0x1800A): DatUnit data;
+        (0x10011 | 0x18011): DataBlockParty data;
+        (0x10012 | 0x18012): ItemBag data;
+        (0x10013 | 0x18013): Money data;
+        (0x10014 | 0x18014): Bitflags data;
+        (0x10015 | 0x18015): Counts data;
+        (0x10016 | 0x18016): PersonaWork data;
+        (0x10017 | 0x18017): AnalysisData data;
+        (0x10018 | 0x18018): CalendarWork data;
+        (0x10019 | 0x18019): ShopData data;
+        (0x1001a | 0x1801a): CommunityData data;
+        (0x1001b | 0x1801b): Quest data;
+        (0x1001c | 0x1801c): PlayerName data;
+        (0x1001d | 0x1801d): PlayerCharacterParam data;
+        (0x1001f | 0x1801f): PublicShop data;
+        (0x10020 | 0x18020): Chat data;
+        (0x10021 | 0x18021): SystemWork data;
+        (0x10022 | 0x18022): NpcFlags data;
+        (0x10023 | 0x18023): FieldSaveData data;
+        (0x10024 | 0x18024): BookWork data;
+        (0x10025 | 0x18025): QuestOrder data;
+        (0x10026 | 0x18026): NetVoice data;
+        (0x10027 | 0x18027): ArbeitManager data;
+        (0x10028 | 0x18028): TrophyManager data;
+        (0x10029 | 0x18029): ItemMainWork data;
+        (0x1002a | 0x1802a): FieldMissionListWork data;
+        (0x1002b | 0x1802b): CursorMemory data;
+        (0x1002c | 0x1802c): FieldCasinoWork data;
+        (0x1002d | 0x1802d): SoundBgmWork data;
+        (0x1002e | 0x1802e): Diary data;
+        (0x1002f | 0x1802f): JoseStampData data;
+        (0x10030 | 0x18030): GunCustomData data;
+        (0x10031 | 0x18031): VelvetRoomSaveData data;
+        (0x10032 | 0x18032): MementosShop data;
+        (0x10033 | 0x18033): SkillCard data;
+        (0x10034 | 0x18034): ChallengeBattle data;
+        (0x10035 | 0x18035): PlayerCharacterData data;
+        (0x30000 | 0x30001): FieldInfo data;
+        (0x30002): FieldSaveLog data;
+        (0x40000): BattlePlayLog data;
+        (0x60000): SystemFlags data;
+        (0x60001): ThievesDenItems data;
+        (0x60002): ThievesDenPoints data;
+        (0x60003): ThievesDenVideo data;
+        (0x60004): ThievesDenMusic data;
+        (0x60005): ThievesDenImage data;
+        (0x60006): ThievesDenAward data;
+        (0x60007): ThievesDenENV data;
+        (0x60008): TycoonData data;
+        (0x60009): KeyAssign data;
+        (0x6000c): ConfigOptions data;
+        (_): u8 data[size][[sealed]];
+    }
+}[[name(std::format("SAVE BLOCK 0x{:X}", block_id)), format("fmt_datablock")]];
+
+fn fmt_datablock(ref DataBlock self) {
+    match (self.block_id) {
+        (0x10001 ... 0x1000A): return fmt_datunit(self.data);
+        (0x18001 ... 0x1800A): return fmt_datunit(self.data);
+        (0x10011 | 0x18011): return fmt_party(self.data);
+        (0x10012 | 0x18012): return "Item Bag";
+        (0x10013 | 0x18013): return fmt_money(self.data);
+        (0x10014 | 0x18014): return "Bitflags";
+        (0x10015 | 0x18015): return "Counts";
+        (0x10016 | 0x18016): return "Persona Compendium Record";
+        (0x10017 | 0x18017): return "Analysis Data";
+        (0x10018 | 0x18018): return fmt_calendar(self.data);
+        (0x10019 | 0x18019): return "P5 Shop Data TODO";
+        (0x1001a | 0x1801a): return "Confidant Data";
+        (0x1001b | 0x1801b): return fmt_quest(self.data);
+        (0x1001c | 0x1801c): return "Player Name";
+        (0x1001d | 0x1801d): return fmt_pc_param(self.data);
+        (0x1001f | 0x1801f): return "Public Shop Data";
+        (0x10020 | 0x18020): return "Chat Data";
+        (0x10021 | 0x18021): return fmt_systemwork(self.data);
+        (0x10022 | 0x18022): return "NPC Flags";
+        (0x10023 | 0x18023): return "Mementos Palace Data";
+        (0x10024 | 0x18024): return "Book Reading";
+        (0x10025 | 0x18025): return "Quest Order TODO";
+        (0x10026 | 0x18026): return "Net Voice TODO";
+        (0x10027 | 0x18027): return "Arbeit Manager TODO";
+        (0x10028 | 0x18028): return "Trophy Manager TODO";
+        (0x10029 | 0x18029): return "Item Main Work TODO";
+        (0x1002a | 0x1802a): return "Field Mission List TODO";
+        (0x1002b | 0x1802b): return "Cursor Memory";
+        (0x1002c | 0x1802c): return "Field Casino TODO";
+        (0x1002d | 0x1802d): return "Sound BGM Data";
+        (0x1002e | 0x1802e): return "Diary (Camp Menu Calendar)";
+        (0x1002f | 0x1802f): return "Jose Stamp Data (Mementos)";
+        (0x10030 | 0x18030): return "Gun Customization Data";
+        (0x10031 | 0x18031): return "Velvet Room Save Data TODO";
+        (0x10032 | 0x18032): return "Mementos Shop Data TODO";
+        (0x10033 | 0x18033): return "Skill Card TODO";
+        (0x10034 | 0x18034): return "Challenge Battle";
+        (0x10035 | 0x18035): return "Player Character Params TODO";
+        (0x30000 | 0x30001): return fmt_fieldinfo(self.data);
+        (0x30002): return "Field Save Log";
+        (0x40000): return "Battle Log Data TODO";
+        (0x60000): return "System Flags";
+        (0x60001): return "Thieves Den Items";
+        (0x60002): return fmt_thievesden_points(self.data);
+        (0x60003): return "Thieves Den Videos";
+        (0x60004): return "Thieves Den BGM";
+        (0x60005): return "Thieves Den Images";
+        (0x60006): return "Thieves Den Awards";
+        (0x60007): return "Thieves Den ENV";
+        (0x60008): return "Thieves Den Tycoon Data";
+        (0x60009): return "Button Config";
+        (0x6000a): return "Activity Data TODO";
+        (0x6000b): return "Save Load Window TODO";
+        (0x6000c): return "Config Options";
+        (0xffffffff): return "EOF";
+        (_): return std::format("TODO", self.block_id); 
+    }
+};
+
+struct SaveFile {
+    EncryptInfo encrypt_info;
+    DataInfo data_info;
+    if (data_info.head_size == 0x1d0)
+        DataHeader data_header;
+    DataVersion version;
+    DataBlock data_blocks[while(!std::mem::eof())][[inline]];
+};
+
+SaveFile contents @ 0x00[[inline]];


### PR DESCRIPTION
Throwing a couple templates to the repo. I made P5R Savefile a couple years ago when I first tried out ImHex and Metaphor's EVT to test extracting type information (names, data types and offsets) for all the event commands from exe (they're called from a method in an event serialization C++ class that the event commands inherit from)