### PR TITLE
add p5r cmpPsCoopSkillTable pattern

### DIFF
--- a/p5r/ftd/ftdEntryStructs.expat
+++ b/p5r/ftd/ftdEntryStructs.expat
@@ -7,6 +7,7 @@
 #include <atlus/p5r/ftd/structs/cmmEventNo.expat>
 #include <atlus/p5r/ftd/structs/cmmFormat.expat>
 #include <atlus/p5r/ftd/structs/cmmFunctionTable.expat>
+#include <atlus/p5r/ftd/structs/cmpPsCoopSkillTable.expat>
 #include <atlus/p5r/ftd/structs/fldWireAnimData.expat>
 #include <atlus/p5r/ftd/structs/fldDngPack.expat>
 #include <atlus/p5r/ftd/structs/datEncountPack.expat>
@@ -30,6 +31,7 @@ struct ftdEntryStruct {
         ("CMMEVENTNO.CTD"): cmmEventNo entry [[name(s)]];
         ("CMMFORMAT.CTD"): cmmFormat entry [[name(s)]];
         ("CMMFUNCTIONTABLE.CTD"): cmmFunctionTable entries[entrySize / 12] [[name(s)]];
+        ("CMPPSCOOPSKILLTABLE.CTD"): cmpPsCoopSkillTable entries[entrySize / 8] [[name(s)]];
         ("FLDWIREANIMDATA.FTD"): fldWireAnimData entry [[name(s)]];
         ("FLDDNGPACK.FTD"): fldDngPack entry [[name(s)]];
         ("FLDPLAYERSPEED.FTD"): fldPlayerSpeed entry [[name(s)]];

--- a/p5r/ftd/structs/cmpPsCoopSkillTable.expat
+++ b/p5r/ftd/structs/cmpPsCoopSkillTable.expat
@@ -1,0 +1,7 @@
+struct cmpPsCoopSkillTable {
+	padding[1];
+	PartyMember partyId;
+	s16 rank; // 11 for third awakening behavior
+	s16 skillId;
+	padding[2];
+};


### PR DESCRIPTION
this ctd defines the skills given by the SKILL_ADD_CMM flowscript function, based on confidant and rank. in practice it's only used for second and third awakening skills but could possibly be used to give relearnable skills across the length of a party confidant